### PR TITLE
Changed attribute naming to be consistent with the rest of BPM.

### DIFF
--- a/addon/bpm-post.js
+++ b/addon/bpm-post.js
@@ -171,7 +171,7 @@ function process_element(store, element, convert_unknown) {
 	if(full_emote !== null) {
 	    log_debug("Found alternate emote.");
 	    name = full_emote[1];
-	    element.setAttribute("bpm_fulltext", full_emote.join("-"));
+	    element.setAttribute("data-bpm_fulltext", full_emote.join("-"));
 	    element.setAttribute("href", full_emote.slice(1).join("-"));
 	    element.setAttribute("data-bpm_tstate", 0);
 	} else {

--- a/addon/bpm-reddit.js
+++ b/addon/bpm-reddit.js
@@ -76,7 +76,7 @@ function toggle_emote(store, element) {
     }
     //If this attribute is set, then the emote has a fallback.
     if(element.hasAttribute("data-bpm_tstate")) {
-        var parts = element.getAttribute("bpm_fulltext").split("-");
+        var parts = element.getAttribute("data-bpm_fulltext").split("-");
 	switch(element.getAttribute("data-bpm_tstate")) {
 	    case "0": //The emote is normal and should be changed to the fallback emote.
 	        var info = store.lookup_emote(parts[1], false);
@@ -98,7 +98,7 @@ function toggle_emote(store, element) {
 		    element.classList.add("bpm-nsfw");
 		}
 		if(state.indexOf("T") > -1) {
-		    element.textContent = element.getAttribute("bpm_fulltext");
+		    element.textContent = element.getAttribute("data-bpm_fulltext");
 		}
 		parts.splice(0, 1);
 		element.setAttribute("href", parts.join("-"));


### PR DESCRIPTION
Attribute `bpm_fulltext` is now `data-bpm_fulltext` to be consistent with the attribute naming in the rest of BPM.